### PR TITLE
Build MSSQL Instance Rather Than Relying On PreBuilt Image

### DIFF
--- a/quickstart/windows/docker-compose.yml
+++ b/quickstart/windows/docker-compose.yml
@@ -4,13 +4,15 @@ version: "3.2"
 
 services:
   fhir-appliance-db:
-    image: synaneticsltd/synfhir-windows-mssql-win-2019:latest
+    build:
+      context: .\sql
+      dockerfile: Dockerfile
     container_name: fhir-appliance-db
     hostname: localhost
     environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Pa55w0rd1! # Change as required (changes here need to be reflected in line 44 of .env)
-      - ATTACH_DBS=[{"dbName":"fhirstore","dbFiles":["C:\\SQLData\\fhirstore.mdf","C:\\SQLData\\fhirstore_log.ldf"]}]
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: Pa55w0rd1!
+      MSSQL_PID: Developer
     ports:
       - 1433:1433
     volumes:

--- a/quickstart/windows/sql/Dockerfile
+++ b/quickstart/windows/sql/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/mssql/server:2019-latest
+COPY ./ /
+# Switch to root user so that exec perms can be granted to init-fhirstore script
+USER root
+# Grant permissions for the init sh so that it is executable
+RUN chmod +x init-fhirstore-db.sh
+# Run entrypoint under mssql user
+USER mssql
+# Go..
+ENTRYPOINT ["/bin/bash", "./entrypoint.sh"]

--- a/quickstart/windows/sql/entrypoint.sh
+++ b/quickstart/windows/sql/entrypoint.sh
@@ -1,0 +1,2 @@
+#start both of these processes in parallel - cmd to start sql server must be last to initialize the fhirstore
+./init-fhirstore-db.sh & /opt/mssql/bin/sqlservr

--- a/quickstart/windows/sql/init-fhirstore-db.sh
+++ b/quickstart/windows/sql/init-fhirstore-db.sh
@@ -1,0 +1,14 @@
+#run the setup script to create the DB and the schema in the DB
+#do this in a loop because the timing for when the SQL instance is ready is indeterminate
+for i in {1..50};
+do
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Pa55w0rd1! -i init-fhirstore-db.sql
+    if [ $? -eq 0 ]
+    then
+        echo "init-fhirstore-db.sql completed"
+        break
+    else
+        echo "not ready yet..."
+        sleep 1
+    fi
+done

--- a/quickstart/windows/sql/init-fhirstore-db.sql
+++ b/quickstart/windows/sql/init-fhirstore-db.sql
@@ -1,0 +1,20 @@
+/* CREATE THE FHIRSTORE LOGIN (iamnode) */
+USE [master];
+GO
+CREATE LOGIN iamnode
+    WITH PASSWORD    = N'Pa55w0rd1!',
+    CHECK_POLICY     = OFF,
+    CHECK_EXPIRATION = OFF;
+GO
+/* CREATE THE fhirstore DB */
+CREATE DATABASE fhirstore;
+GO
+USE fhirstore;
+GO
+/* CREATE THE DBO iamnode USER AND LINKE TO THE iamnode LOGIN */
+IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'iamnode')
+BEGIN
+    CREATE USER [iamnode] FOR LOGIN [iamnode]
+    EXEC sp_addrolemember N'db_owner', N'iamnode'
+END;
+GO


### PR DESCRIPTION
This means when switching between different versions of the windows OS, we don't need to maintain different versions of this image built on different OS's. As this is just a sample project to get people up and running having a fixed image is not required.