### PR TITLE
Replace LOG_LEVEL with LOGLEVEL

### DIFF
--- a/prod/.env
+++ b/prod/.env
@@ -258,9 +258,9 @@ MAXPAGESIZE=1000
 # The maximum number of concurrent database clients (for Postgres only)
 MAX_CLIENTS=10
 #
-# Logging - LOG_LEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
+# Logging - LOGLEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
 LOGGER=true
-LOG_LEVEL=debug
+LOGLEVEL=debug
 #
 # Tracing - Set to true if you wish to view console message traces
 TRACE_CONSOLE=false

--- a/quickstart/linux/.env
+++ b/quickstart/linux/.env
@@ -255,9 +255,9 @@ MAXPAGESIZE=1000
 # The maximum number of concurrent database clients (for Postgres only)
 MAX_CLIENTS=10
 #
-# Logging - LOG_LEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
+# Logging - LOGLEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
 LOGGER=true
-LOG_LEVEL=debug
+LOGLEVEL=debug
 #
 # Tracing - Set to true if you wish to view console message traces
 TRACE_CONSOLE=false

--- a/quickstart/windows/.env
+++ b/quickstart/windows/.env
@@ -256,9 +256,9 @@ MAXPAGESIZE=1000
 # The maximum number of concurrent database clients (for Postgres only)
 MAX_CLIENTS=10
 #
-# Logging - LOG_LEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
+# Logging - LOGLEVEL is DEBUG by default but can be one of the standard log level settings: debug|info|warn|error
 LOGGER=true
-LOG_LEVEL=debug
+LOGLEVEL=debug
 #
 # Tracing - Set to true if you wish to view console message traces
 TRACE_CONSOLE=false


### PR DESCRIPTION
Fixes the naming of `LOGLEVEL` in the sample `.env` files.